### PR TITLE
Changed extractCurrencyCode to split String using '-'.

### DIFF
--- a/src/main/java/edu/jeramiah/utsa/currencyconvertergui/CurrencyConverterController.java
+++ b/src/main/java/edu/jeramiah/utsa/currencyconvertergui/CurrencyConverterController.java
@@ -76,7 +76,7 @@ public class CurrencyConverterController {
     }
 
     private String extractCurrencyCode(String choiceBoxValue) {
-        final String[] CURRENCY_ATTRIBUTES = choiceBoxValue.split(",");
+        final String[] CURRENCY_ATTRIBUTES = choiceBoxValue.split("-");
         return CURRENCY_ATTRIBUTES[0].trim();
     }
 


### PR DESCRIPTION
extractCurrencyCodes now splits the string by '-' instead of '-' in order to restore functionality of the conversion request